### PR TITLE
Default to saving ICS on filesystem and documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ This tool **does not** use the Facebook API.
 * Google Drive API access (optional)
 
 ## Instructions
+### Save ics for manual upload to Google Calendar (easier)
+1. Clone repo
+`git clone git@github.com:mobeigi/fb2cal.git`
+2. Rename `config/config-template.ini` to `config/config.ini` and enter your Facebook email and password.
+3. Install required python modules   
+`pip install -r requirements.txt`
+4. Run script manually once for testing purposes:
+`python src/fb2cal.py`
+5. Import the created `birthdays.ics` file to Google Drive.  
+### Direct Upload to Google Calendar
 1. Clone repo  
 `git clone git@github.com:mobeigi/fb2cal.git`
 2. Create a Google Drive API credentials
@@ -42,7 +52,7 @@ This tool **does not** use the Facebook API.
    5. Create Credentials (**OAuth client ID**)
    5. Download credentials JSON file
 3. Rename credentials JSON file to **credentials.json** and put it in the `src` folder
-4. Rename `config/config-template.ini` to `config/config.ini` and enter your Facebook email and password as well as a name for your calender to be saved on Google Drive. Initially, the value for the **drive_file_id** field should be empty.
+4. Rename `config/config-template.ini` to `config/config.ini` and enter your Facebook email and password as well as a name for your calender to be saved on Google Drive. Change `upload_to_drive` to `True`. Initially, the value for the **drive_file_id** field should be empty.
 5. Install required python modules   
 `pip install -r requirements.txt`
 6. Run script manually once for testing purposes:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This tool **does not** use the Facebook API.
 * Google Drive API access (optional)
 
 ## Instructions
-### Save ics for manual upload to Google Calendar (easier)
+### Option 1: Save ics for manual upload to Google Calendar 
 1. Clone repo
 `git clone git@github.com:mobeigi/fb2cal.git`
 2. Rename `config/config-template.ini` to `config/config.ini` and enter your Facebook email and password.
@@ -41,7 +41,7 @@ This tool **does not** use the Facebook API.
 4. Run script manually once for testing purposes:
 `python src/fb2cal.py`
 5. Import the created `birthdays.ics` file to Google Drive.  
-### Direct Upload to Google Calendar
+### Option 2: Direct Upload to Google Calendar
 1. Clone repo  
 `git clone git@github.com:mobeigi/fb2cal.git`
 2. Create a Google Drive API credentials

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This tool **does not** use the Facebook API.
 2. Rename `config/config-template.ini` to `config/config.ini` and enter your Facebook email and password.
 3. Install required python modules   
 `pip install -r requirements.txt`
-4. Run script manually once for testing purposes:
+4. Run the script manually:
 `python src/fb2cal.py`
 5. Import the created `birthdays.ics` file to Google Drive.  
 ### Option 2: Direct Upload to Google Calendar

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 ## Description
-Around 20 June 2019, Facebook removed their Facebook Birthday ics export option.  
+Around 20 June 2019, Facebook removed their Facebook Birthday ICS export option.  
 This change was unannounced and no reason was ever released.  
 
 fb2cal is a tool which restores this functionality.  
@@ -32,7 +32,7 @@ This tool **does not** use the Facebook API.
 * Google Drive API access (optional)
 
 ## Instructions
-### Option 1: Save ics for manual upload to Google Calendar 
+### Option 1: Save ICS file to filesystem 
 1. Clone repo
 `git clone git@github.com:mobeigi/fb2cal.git`
 2. Rename `config/config-template.ini` to `config/config.ini` and enter your Facebook email and password.
@@ -40,8 +40,8 @@ This tool **does not** use the Facebook API.
 `pip install -r requirements.txt`
 4. Run the script manually:
 `python src/fb2cal.py`
-5. Import the created `birthdays.ics` file to Google Drive.  
-### Option 2: Direct Upload to Google Calendar
+5. Import the created `birthdays.ics` file into Calendar applications (i.e. Google Calendar)
+### Option 2: Automatically Upload ICS file to Google Drive
 1. Clone repo  
 `git clone git@github.com:mobeigi/fb2cal.git`
 2. Create a Google Drive API credentials
@@ -57,9 +57,9 @@ This tool **does not** use the Facebook API.
 `pip install -r requirements.txt`
 6. Run script manually once for testing purposes:
 `python ./fb2cal.py`
-7. Check Google Drive to ensure your ics file was made. 
-8. Setup Cron Jobs/Task Scheduler/Automator to repeatedly run the script to periodically generate an updated ics file. See **Scheduled Task Frequency** section for more info.
-9. Use the following link to import your ics into Calendar applications (i.e. Google Calendar):  
+7. Check Google Drive to ensure your ICS file was made. 
+8. Setup Cron Jobs/Task Scheduler/Automator to repeatedly run the script to periodically generate an updated ICS file. See **Scheduled Task Frequency** section for more info.
+9. Use the following link to import your ICS file into Calendar applications (i.e. Google Calendar):  
 `http://drive.google.com/uc?export=download&id=DRIVE_FILE_ID`. Replace **DRIVE_FILE_ID** with the autopopulated value found in your `config/config.ini` file.
 
 ## Configuration

--- a/config/config-template.ini
+++ b/config/config-template.ini
@@ -4,12 +4,12 @@ fb_email =
 fb_pass = 
 
 [DRIVE]
-upload_to_drive = True
+upload_to_drive = False
 drive_file_id = 
 ics_file_name = birthdays.ics
 
 [FILESYSTEM]
-save_to_file = False
+save_to_file = True
 ics_file_path = ./birthdays.ics
 
 [LOGGING]


### PR DESCRIPTION
With a growing number of people moving away from Facebook, more and more people will want to use this script (as FB removed the ability to download birthdays directly). Adding simple instructions for use of the script without automatic upload to google calendar, and defaulting to saving the file may make it more user friendly. 