### PR TITLE
Some entries don't have vertical_type 

### DIFF
--- a/src/fb2cal.py
+++ b/src/fb2cal.py
@@ -697,7 +697,7 @@ def get_entity_id_from_vanity_name(browser, vanity_name):
     composer_query_entries = get_composer_query_entries(browser, vanity_name)
     for entry in composer_query_entries:
         # Skip other render types like commerce pages etc
-        if entry['vertical_type'] != 'USER' and entry['render_type'] not in ['friend', 'non_friend']:
+        if 'vertical_type' in entry and entry['vertical_type'] != 'USER' and entry['render_type'] not in ['friend', 'non_friend']:
             continue
 
         if 'alias' in entry and entry['alias'] == vanity_name:

--- a/src/fb2cal.py
+++ b/src/fb2cal.py
@@ -697,7 +697,7 @@ def get_entity_id_from_vanity_name(browser, vanity_name):
     composer_query_entries = get_composer_query_entries(browser, vanity_name)
     for entry in composer_query_entries:
         # Skip other render types like commerce pages etc
-        if 'vertical_type' in entry and entry['vertical_type'] != 'USER' and entry['render_type'] not in ['friend', 'non_friend']:
+        if 'vertical_type' in entry and entry['vertical_type'] != 'USER' and 'render_type' in entry and entry['render_type'] not in ['friend', 'non_friend']:
             continue
 
         if 'alias' in entry and entry['alias'] == vanity_name:


### PR DESCRIPTION
Fix KeyError

I faced this error while running the script : 

```
Traceback (most recent call last):
  File "./fb2cal.py", line 815, in <module>
    main()
  File "./fb2cal.py", line 117, in main
    birthdays = get_async_birthdays(browser)
  File "./fb2cal.py", line 401, in get_async_birthdays
    birthdays_for_month = parse_birthday_async_output(browser, response.text)
  File "./fb2cal.py", line 460, in parse_birthday_async_output
    uid = get_entity_id_from_vanity_name(browser, vanity_name)
  File "./fb2cal.py", line 700, in get_entity_id_from_vanity_name
    if entry['vertical_type'] != 'USER' and entry['render_type'] not in ['friend', 'non_friend']:
KeyError: 'vertical_type'
```

Just this minor change fixed it. 