### PR TITLE
Use vanity_names instead of entity_ids for VEVENT UID

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ It is recommended to run the script **once every 24 hours** to update the ICS fi
 * During Facebook authentication, a security checkpoint may trigger that will force you to change your Facebook password.
 * Some locales are currently not supported (see [#13](../../issues/13))
 * Some supported locales may fail. Consider changing your Facebook language to English temporarily as a workaround. (see [#52](../../issues/52))
+* Duplicate birthday events may appear if calendar is reimported after Facebook friends change their username due to performance optimizations. (see [#65](../../pull/65))
 
 ## Contributions
 Contributions are always welcome!

--- a/src/fb2cal.py
+++ b/src/fb2cal.py
@@ -455,7 +455,7 @@ def parse_birthday_async_output(browser, text):
     for vanity_name, tooltip_content, name in regexp.findall(birthday_card_html):
         # Generate a unique ID in compliance with RFC 2445 ICS - 4.8.4.7 Unique Identifier
         trim_start = 15 if vanity_name.startswith('profile.php?id=') else 0
-        uid = f'{vanity_name[trim_start:]}@github/mobeigi/fb2cal'
+        uid = f'{vanity_name[trim_start:]}@github.com/mobeigi/fb2cal'
         
         # Parse tooltip content into day/month
         day, month = parse_birthday_day_month(tooltip_content, name, user_locale)
@@ -686,36 +686,6 @@ def get_day_name_offset_dict(user_locale):
     # Failure
     logger.error(f"Failed to generate day name offset dictionary for provided user locale: '{user_locale}'")
     raise SystemError
-
-def get_composer_query_entries(browser, value):
-    """ Get list of entries from the composer query endpoint """
-
-    COMPOSER_QUERY_ASYNC_ENDPOINT = "https://www.facebook.com/ajax/mercury/composer_query.php?"
-
-    # Not all fields are required for response to be given, required fields are value, fb_dtsg_ag and __a
-    query_params = {'value': value,
-                    'fb_dtsg_ag': get_async_token(browser),
-                    '__a': '1'}
-
-    response = browser.get(COMPOSER_QUERY_ASYNC_ENDPOINT + urllib.parse.urlencode(query_params))
-    
-    if response.status_code != 200:
-        logger.debug(response.text)
-        logger.warning(f'Failed to get async composer query response. Params: {query_params}. Status code: {response.status_code}.')
-        return []
-
-    # Parse json response
-    try:
-        json_response = json.loads(strip_ajax_response_prefix(response.text))
-        return json_response['payload']['entries']
-    except json.decoder.JSONDecodeError as e:
-        logger.debug(response.text)
-        logger.warning(f'JSONDecodeError: {e}')
-        return []
-    except KeyError as e:
-        logger.debug(json_response)
-        logger.warning(f'KeyError: {e}')
-        return []
 
 def strip_ajax_response_prefix(payload):
     """ Strip the prefix that Facebook puts in front of AJAX responses """


### PR DESCRIPTION
First off, thank you so much for creating this project! Not having birthdays from Facebook in my calendar anymore has been a major pain, which fb2cal has fixed! So thank you thank you thank you!

I was running into periodic issues with the current entity_id retrieval (probably due to the rate limiting problems you mention elsewhere). It led me to pursue a different approach to generating the UIDs:

> This change uses vanity_name in ICS (RFC 2445) compliant manner, instead of retrieving the entity_id. It follows the guidance in the RFC to include domain (or domain-like) information with the identifier to make it globally unique.

In my trials, this shaves a ~1700 birthday run from ~18 minutes to ~10 seconds.

However, I realize that since this script is intended for cron-like execution, the vanity_names may not provide a sufficiently stable identifier, because users can change them. Therefore, I would propose extending this PR to include an argument flag allowing the user to decide if they want to retrieve proper entity_ids (the default) or shortcut and just use vanity names (this PR).

I haven't implemented this extension, but I'd be more than happy to if it made this PR acceptable for you.