### PR TITLE
Adding a line to fix errors with ICS format regarding lack of DTSTAMP

### DIFF
--- a/src/fb2cal.py
+++ b/src/fb2cal.py
@@ -712,6 +712,7 @@ def populate_birthdays_calendar(birthdays):
     for birthday in birthdays:
         e = Event()
         e.uid = birthday.uid
+        e.created = cur_date
         e.name = f"{birthday.name}'s Birthday"
 
         # Calculate the year as this year or next year based on if its past current month or not


### PR DESCRIPTION
When I was trying to upload my calendar to Nextcloud, I encountered an error stating the ics was invalid. I went on iCalendar validator to see what went wrong and noticed that DTSTAMP is not specified. I added one line to add this property.
![image](https://user-images.githubusercontent.com/43486117/91515916-9d4b9d80-e92d-11ea-81b4-e548c48d9d62.png)
