### PR TITLE
Don't explicitly specify parser so we use the best available.

### DIFF
--- a/src/fb2cal.py
+++ b/src/fb2cal.py
@@ -542,7 +542,7 @@ def parse_birthday_day_month(tooltip_content, name, user_locale):
         cur_date = datetime.now()
 
         # Use beautiful soup to parse special html codes properly before matching with our dict
-        day_name = BeautifulSoup(birthday_date_str, 'lxml').get_text().lower()
+        day_name = BeautifulSoup(birthday_date_str).get_text().lower()
 
         if day_name in offset_dict:
             cur_date = cur_date + relativedelta(days=offset_dict[day_name])


### PR DESCRIPTION
If we don't specify `lxml` we won't run into problems in scenarios where it does not exist.
We will still keep it in requirements so it is installed in the pipenv in case it is more performant (which it should be).


Fixes #68