### PR TITLE
Remove unused lxml requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 MechanicalSoup
 ics>=0.6
 requests
-lxml


### PR DESCRIPTION
No longer used for parsing at all since #81 