### PR TITLE
Avoid double 's' in ICS event name (#83)

### DIFF
--- a/fb2cal/ics_writer.py
+++ b/fb2cal/ics_writer.py
@@ -31,7 +31,10 @@ class ICSWriter:
             e = Event()
             e.uid = facebook_user.id
             e.created = cur_date
-            e.name = f"{facebook_user.name}'s Birthday"
+
+            # Don't add extra 's' if name already ends with 's'
+            formatted_username = f"{facebook_user.name}'s" if facebook_user.name[-1] != 's' else f"{facebook_user.name}'"
+            e.name = f"{formatted_username} Birthday"
 
             # Calculate the year as this year or next year based on if its past current month or not
             # Also pad day, month with leading zeros to 2dp

--- a/tests/test_ics_writer.py
+++ b/tests/test_ics_writer.py
@@ -56,6 +56,14 @@ class TestICSWriter(unittest.TestCase):
                 31,
                 12,
             ),
+            FacebookUser(
+                '100000006', 
+                'Bob Jones',
+                'https://www.facebook.com/bob.jones', 
+                'https://scontent-syd2-1.xx.fbcdn.net/v/t1.0-1/cp0/p60x60/00000005_10161077510019848_299841799451806933_o.jpg',
+                24,
+                5,
+            ),
         ]
         self.ics_writer = ICSWriter(self.facebook_users)
         self.maxDiff = None
@@ -120,6 +128,14 @@ DTSTAMP:20201113T071402Z
 DURATION:P1D
 SUMMARY:Mónica Bellucci's Birthday
 UID:100000005
+END:VEVENT
+BEGIN:VEVENT
+RRULE:FREQ=YEARLY
+DTSTART;VALUE=DATE:20210524
+DTSTAMP:20201113T071402Z
+DURATION:P1D
+SUMMARY:Bob Jones' Birthday
+UID:100000006
 END:VEVENT
 METHOD:PUBLISH
 PRODID:fb2cal v1.2.0 (Production) [https://git.io/fjMwr]


### PR DESCRIPTION
Resolves #83 
Changes:
- Do not add an extra 's' if the name already ends with 's'

Testing:
- added a test case to `test_ics_writer`
- manually tested this