### PR TITLE
Use c_user cookie to verify user has logged in successfully

### DIFF
--- a/fb2cal/facebook_browser.py
+++ b/fb2cal/facebook_browser.py
@@ -62,8 +62,12 @@ class FacebookBrowser:
             raise SystemError
 
         # Check to see if login failed
-        if login_response.soup.find('link', {'rel': 'canonical', 'href': 'https://www.facebook.com/login/'}):
+        # We do this by checking to see if the `c_user` cookie is set to the users numeric Facebook ID
+        c_user = self.browser.get_cookiejar().get('c_user', default=None)
+
+        if not c_user or not c_user.isnumeric():
             self.logger.debug(login_response.text)
+            self.logger.debug(f'Cookie(c_user) : {c_user}')
             self.logger.error(f'Failed to authenticate with Facebook with email {email}. Please check provided email/password.')
             raise SystemError
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 MechanicalSoup
 ics>=0.6
 requests
+freezegun

--- a/tests/test_ics_writer.py
+++ b/tests/test_ics_writer.py
@@ -1,7 +1,6 @@
 import unittest
-from unittest.mock import patch
-from datetime import datetime, date
-from ics import Calendar, Event
+from ics import Calendar
+from freezegun import freeze_time
 
 from fb2cal import ICSWriter, FacebookUser
 
@@ -68,12 +67,8 @@ class TestICSWriter(unittest.TestCase):
         self.ics_writer = ICSWriter(self.facebook_users)
         self.maxDiff = None
 
+    @freeze_time("2020-12-01")
     def test_ics_writer_equivalence(self):
-        
-        with patch('datetime.date') as mock_date:
-            mock_date.now.return_value = date(2010, 10, 8)
-            print(datetime.now())
-
         self.ics_writer.generate()
         actual_calendar = self.ics_writer.get_birthday_calendar()
         expected = """BEGIN:VCALENDAR


### PR DESCRIPTION
Context: https://github.com/mobeigi/fb2cal/issues/96

Changes:

- Use c_user cookie (set on successful login) to verify login vs various DOM elements existing, this is more robust 
- Fix time mock for unit tests (they were never working in the first place)