### PR TITLE
Fixes #40, #97: Add support for year of birth

### DIFF
--- a/fb2cal/__main__.py
+++ b/fb2cal/__main__.py
@@ -69,8 +69,8 @@ try:
     logger.info('Fetching all Birthdays via BirthdayCometRootQuery endpoint...')
     # TODO: See #97, offset_month of 10 is needed here because offset months 6/7 are currently returning equivalent months
     for offset_month in [0, 3, 6, 9, 10]:
-        birthday_comet_root_json = facebook_browser.query_graph_ql_birthday_comet_root(offset_month)
-        facebook_users_for_quarter = transformer.transform_birthday_comet_root_to_birthdays(birthday_comet_root_json)
+        birthday_comet_monthly_json = facebook_browser.query_graph_ql_birthday_comet_monthly(offset_month)
+        facebook_users_for_quarter = transformer.transform_birthday_comet_monthly_to_birthdays(birthday_comet_monthly_json)
         facebook_users.update(facebook_users_for_quarter)
 
     if len(facebook_users) == 0:

--- a/fb2cal/__main__.py
+++ b/fb2cal/__main__.py
@@ -67,8 +67,7 @@ try:
 
     # Endpoint will return all birthdays for offset_month plus the following 2 consecutive months.
     logger.info('Fetching all Birthdays via BirthdayCometRootQuery endpoint...')
-    # TODO: See #97, offset_month of 10 is needed here because offset months 6/7 are currently returning equivalent months
-    for offset_month in [0, 3, 6, 9, 10]:
+    for offset_month in [0, 3, 6, 9]:
         birthday_comet_monthly_json = facebook_browser.query_graph_ql_birthday_comet_monthly(offset_month)
         facebook_users_for_quarter = transformer.transform_birthday_comet_monthly_to_birthdays(birthday_comet_monthly_json)
         facebook_users.update(facebook_users_for_quarter)

--- a/fb2cal/facebook_browser.py
+++ b/fb2cal/facebook_browser.py
@@ -105,13 +105,13 @@ class FacebookBrowser:
         
         return self.__cached_token
 
-    def query_graph_ql_birthday_comet_root(self, offset_month):
-        """ Query the GraphQL BirthdayCometRootQuery endpoint that powers the https://www.facebook.com/events/birthdays page 
+    def query_graph_ql_birthday_comet_monthly(self, offset_month):
+        """ Query the GraphQL BirthdayCometMonthlyBirthdaysRefetchQuery endpoint that powers the https://www.facebook.com/events/birthdays page 
             This endpoint will return all Birthdays for the offset_month plus the following 2 consecutive months. """
 
         FACEBOOK_GRAPHQL_ENDPOINT = 'https://www.facebook.com/api/graphql/'
-        FACEBOOK_GRAPHQL_API_REQ_FRIENDLY_NAME = 'BirthdayCometRootQuery'
-        DOC_ID = 3382519521824494
+        FACEBOOK_GRAPHQL_API_REQ_FRIENDLY_NAME = 'BirthdayCometMonthlyBirthdaysRefetchQuery'
+        DOC_ID = 5347559575302259
 
         variables = {
             'offset_month': offset_month,

--- a/fb2cal/facebook_user.py
+++ b/fb2cal/facebook_user.py
@@ -14,7 +14,7 @@ class FacebookUser:
     def __str__(self):
         day = f'{self.birthday_day:02}' if self.birthday_day else UNKNOWN_CHAR*2
         month = f'{self.birthday_month:02}' if self.birthday_month else UNKNOWN_CHAR*2
-        year = str(self.birthday_year) if self.birthday_year else UNKNOWN_CHAR*4
+        year = f'{self.birthday_year:04}' if self.birthday_year else UNKNOWN_CHAR*4
         formatted_birthday = DATE_SEPERATOR.join(filter(None, (day, month, year)))
         return f'{self.name} ({formatted_birthday})'
 

--- a/fb2cal/facebook_user.py
+++ b/fb2cal/facebook_user.py
@@ -1,17 +1,22 @@
+DATE_SEPERATOR = '/'
+UNKNOWN_CHAR = '?'
+
 class FacebookUser:
-    def __init__(self, id, name, profile_url, profile_picture_uri, birthday_day, birthday_month):
+    def __init__(self, id, name, profile_url, profile_picture_uri, birthday_day, birthday_month, birthday_year):
         self.id = id
         self.name = name
         self.profile_url = profile_url
         self.profile_picture_uri = profile_picture_uri
         self.birthday_day = birthday_day
         self.birthday_month = birthday_month
+        self.birthday_year = birthday_year
 
     def __str__(self):
-        return f'{self.name} ({self.birthday_day}/{self.birthday_month})'
-    
-    def __unicode__(self):
-        return u'{self.name} ({self.birthday_day}/{self.birthday_month})'
+        day = f'{self.birthday_day:02}' if self.birthday_day else UNKNOWN_CHAR*2
+        month = f'{self.birthday_month:02}' if self.birthday_month else UNKNOWN_CHAR*2
+        year = str(self.birthday_year) if self.birthday_year else UNKNOWN_CHAR*4
+        formatted_birthday = DATE_SEPERATOR.join(filter(None, (day, month, year)))
+        return f'{self.name} ({formatted_birthday})'
 
     def __lt__(self, other):
         return (self.birthday_month < other.birthday_month) and (self.birthday_day < other.birthday_month)
@@ -21,4 +26,3 @@ class FacebookUser:
 
     def __hash__(self):
         return hash(self.id)
-    

--- a/fb2cal/transformer.py
+++ b/fb2cal/transformer.py
@@ -2,15 +2,15 @@ from .facebook_user import FacebookUser
 
 class Transformer:
 
-    def transform_birthday_comet_root_to_birthdays(self, birthday_comet_root_json):
-        """ Transforms outfrom from BirthdayCometRootQuery to list of Birthdays """
+    def transform_birthday_comet_monthly_to_birthdays(self, birthday_comet_root_json):
+        """ Transforms outfrom from BirthdayCometMonthlyBirthdaysRefetchQuery to list of Birthdays """
 
         facebook_users = []
 
         for all_friends_by_birthday_month_edge in birthday_comet_root_json['data']['viewer']['all_friends_by_birthday_month']['edges']:
             for friend_edge in all_friends_by_birthday_month_edge['node']['friends']['edges']:
                 friend = friend_edge['node']
-
+                
                 # Create Birthday object
                 facebook_users.append(
                     FacebookUser(
@@ -19,7 +19,8 @@ class Transformer:
                         friend["profile_url"],
                         friend["profile_picture"]["uri"],
                         friend["birthdate"]["day"],
-                        friend["birthdate"]["month"]
+                        friend["birthdate"]["month"],
+                        friend["birthdate"]["year"]
                 ))
                 
         return facebook_users

--- a/tests/mocks/birthday_comet_root_mocks.py
+++ b/tests/mocks/birthday_comet_root_mocks.py
@@ -1956,7 +1956,8 @@ BIRTHDAY_COMET_ROOT_JANUARY_MOCK = {
                                  },
                                  "birthdate":{
                                     "day":1,
-                                    "month":11
+                                    "month":11,
+                                    "year":1982
                                  },
                                  "__module_operation_BirthdayCometMonthlyBirthdaysCard_allFriendsByBirthdayMonthEdge":{
                                     "__dr":"BirthdayCometProfilePictureOnUser_user$normalization.graphql"
@@ -2019,7 +2020,8 @@ BIRTHDAY_COMET_ROOT_JANUARY_MOCK = {
                                  },
                                  "birthdate":{
                                     "day":25,
-                                    "month":12
+                                    "month":12,
+                                    "year":None
                                  },
                                  "__module_operation_BirthdayCometMonthlyBirthdaysCard_allFriendsByBirthdayMonthEdge":{
                                     "__dr":"BirthdayCometProfilePictureOnUser_user$normalization.graphql"
@@ -2082,7 +2084,8 @@ BIRTHDAY_COMET_ROOT_JANUARY_MOCK = {
                                  },
                                  "birthdate":{
                                     "day":17,
-                                    "month":1
+                                    "month":1,
+                                    "year":1881
                                  },
                                  "__module_operation_BirthdayCometMonthlyBirthdaysCard_allFriendsByBirthdayMonthEdge":{
                                     "__dr":"BirthdayCometProfilePictureOnUser_user$normalization.graphql"

--- a/tests/test_ics_writer.py
+++ b/tests/test_ics_writer.py
@@ -14,6 +14,7 @@ class TestICSWriter(unittest.TestCase):
                 'https://scontent-syd2-1.xx.fbcdn.net/v/t1.0-1/cp0/p60x60/00000001_10161077510019848_299841799451806933_o.jpg',
                 20,
                 1,
+                1994
             ),
             FacebookUser(
                 '100000001', 
@@ -22,6 +23,7 @@ class TestICSWriter(unittest.TestCase):
                 'https://scontent-syd2-1.xx.fbcdn.net/v/t1.0-1/cp0/p60x60/00000002_10161077510019848_299841799451806933_o.jpg',
                 12,
                 3,
+                1974
             ),
             FacebookUser(
                 '100000002', 
@@ -30,6 +32,7 @@ class TestICSWriter(unittest.TestCase):
                 'https://scontent-syd2-1.xx.fbcdn.net/v/t1.0-1/cp0/p60x60/00000002_10161077510019848_299841799451806933_o.jpg',
                 6,
                 6,
+                2001
             ),
             FacebookUser(
                 '100000003', 
@@ -38,6 +41,7 @@ class TestICSWriter(unittest.TestCase):
                 'https://scontent-syd2-1.xx.fbcdn.net/v/t1.0-1/cp0/p60x60/00000003_10161077510019848_299841799451806933_o.jpg',
                 26,
                 10,
+                1987
             ),
             FacebookUser(
                 '100000004', 
@@ -46,6 +50,7 @@ class TestICSWriter(unittest.TestCase):
                 'https://scontent-syd2-1.xx.fbcdn.net/v/t1.0-1/cp0/p60x60/00000004_10161077510019848_299841799451806933_o.jpg',
                 29,
                 2,
+                2004
             ),
             FacebookUser(
                 '100000005', 
@@ -54,6 +59,7 @@ class TestICSWriter(unittest.TestCase):
                 'https://scontent-syd2-1.xx.fbcdn.net/v/t1.0-1/cp0/p60x60/00000005_10161077510019848_299841799451806933_o.jpg',
                 31,
                 12,
+                None
             ),
             FacebookUser(
                 '100000006', 
@@ -62,6 +68,7 @@ class TestICSWriter(unittest.TestCase):
                 'https://scontent-syd2-1.xx.fbcdn.net/v/t1.0-1/cp0/p60x60/00000005_10161077510019848_299841799451806933_o.jpg',
                 24,
                 5,
+                None
             ),
         ]
         self.ics_writer = ICSWriter(self.facebook_users)
@@ -78,45 +85,45 @@ X-ORIGINAL-URL:/events/birthdays/
 CALSCALE:GREGORIAN
 BEGIN:VEVENT
 RRULE:FREQ=YEARLY
-DTSTART;VALUE=DATE:20210120
+DTSTART;VALUE=DATE:19940120
 DTSTAMP:20201113T071402Z
-DESCRIPTION:John Smith\\nhttps://www.facebook.com/100000000
+DESCRIPTION:John Smith (20/01/1994)\\nhttps://www.facebook.com/100000000
 DURATION:P1D
 SUMMARY:John Smith's Birthday
 UID:100000000
 END:VEVENT
 BEGIN:VEVENT
 RRULE:FREQ=YEARLY
-DTSTART;VALUE=DATE:20210312
+DTSTART;VALUE=DATE:19740312
 DTSTAMP:20201113T071402Z
-DESCRIPTION:Laura Daisy\\nhttps://www.facebook.com/100000001
+DESCRIPTION:Laura Daisy (12/03/1974)\\nhttps://www.facebook.com/100000001
 DURATION:P1D
 SUMMARY:Laura Daisy's Birthday
 UID:100000001
 END:VEVENT
 BEGIN:VEVENT
 RRULE:FREQ=YEARLY
-DTSTART;VALUE=DATE:20210606
+DTSTART;VALUE=DATE:20010606
 DTSTAMP:20201113T071402Z
-DESCRIPTION:韩忠清\\nhttps://www.facebook.com/100000002
+DESCRIPTION:韩忠清 (06/06/2001)\\nhttps://www.facebook.com/100000002
 DURATION:P1D
 SUMMARY:韩忠清's Birthday
 UID:100000002
 END:VEVENT
 BEGIN:VEVENT
 RRULE:FREQ=YEARLY
-DTSTART;VALUE=DATE:20211026
+DTSTART;VALUE=DATE:19871026
 DTSTAMP:20201113T071402Z
-DESCRIPTION:حكيم هديّة\\nhttps://www.facebook.com/100000003
+DESCRIPTION:حكيم هديّة (26/10/1987)\\nhttps://www.facebook.com/100000003
 DURATION:P1D
 SUMMARY:حكيم هديّة's Birthday
 UID:100000003
 END:VEVENT
 BEGIN:VEVENT
 RRULE:FREQ=YEARLY
-DTSTART;VALUE=DATE:20210228
+DTSTART;VALUE=DATE:20040229
 DTSTAMP:20201113T071402Z
-DESCRIPTION:Leap Year\\nhttps://www.facebook.com/100000004
+DESCRIPTION:Leap Year (29/02/2004)\\nhttps://www.facebook.com/100000004
 DURATION:P1D
 SUMMARY:Leap Year's Birthday
 UID:100000004
@@ -125,7 +132,7 @@ BEGIN:VEVENT
 RRULE:FREQ=YEARLY
 DTSTART;VALUE=DATE:20201231
 DTSTAMP:20201113T071402Z
-DESCRIPTION:Mónica Bellucci\\nhttps://www.facebook.com/100000005
+DESCRIPTION:Mónica Bellucci (31/12/????)\\nhttps://www.facebook.com/100000005
 DURATION:P1D
 SUMMARY:Mónica Bellucci's Birthday
 UID:100000005
@@ -134,7 +141,7 @@ BEGIN:VEVENT
 RRULE:FREQ=YEARLY
 DTSTART;VALUE=DATE:20210524
 DTSTAMP:20201113T071402Z
-DESCRIPTION:Bob Jones\\nhttps://www.facebook.com/100000006
+DESCRIPTION:Bob Jones (24/05/????)\\nhttps://www.facebook.com/100000006
 DURATION:P1D
 SUMMARY:Bob Jones' Birthday
 UID:100000006

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -6,7 +6,7 @@ from mocks.birthday_comet_root_mocks import BIRTHDAY_COMET_ROOT_JANUARY_MOCK
 class TestTransformer(unittest.TestCase):
     def setUp(self):
         self.transformer = Transformer()
-        self.facebook_users = self.transformer.transform_birthday_comet_root_to_birthdays(BIRTHDAY_COMET_ROOT_JANUARY_MOCK)
+        self.facebook_users = self.transformer.transform_birthday_comet_monthly_to_birthdays(BIRTHDAY_COMET_ROOT_JANUARY_MOCK)
 
     def test_count(self):
         self.assertEqual(len(self.facebook_users), 3)
@@ -19,6 +19,7 @@ class TestTransformer(unittest.TestCase):
         self.assertEqual(friend.profile_picture_uri, 'https://scontent-syd2-1.xx.fbcdn.net/v/t1.0-1/cp0/p60x60/122897864_10161077510019848_299841799681806933_o.jpg?_nc_cat=107&ccb=2&_nc_sid=7206a8&_nc_ohc=yzAYhtdvoMYAX9Zxo1e&_nc_ht=scontent-syd2-1.xx&tp=27&oh=dc48247e31223151bc5d55781a572e2f&oe=5FD254D0')
         self.assertEqual(friend.birthday_day, 1)
         self.assertEqual(friend.birthday_month, 11)
+        self.assertEqual(friend.birthday_year, 1982)
 
     def test_friend_in_december(self):
         friend = self.facebook_users[1]
@@ -28,6 +29,7 @@ class TestTransformer(unittest.TestCase):
         self.assertEqual(friend.profile_picture_uri, 'https://scontent-syd2-1.xx.fbcdn.net/v/t1.0-1/cp0/p60x60/53497864_10161077510019848_299841799451806933_o.jpg?_nc_cat=107&ccb=2&_nc_sid=7206a8&_nc_ohc=yzAYhtdvoMYAX9Zxo1e&_nc_ht=scontent-syd2-1.xx&tp=27&oh=dc48247e31223151bc5d55781a572e2f&oe=5FD254D0')
         self.assertEqual(friend.birthday_day, 25)
         self.assertEqual(friend.birthday_month, 12)
+        self.assertEqual(friend.birthday_year, None)
 
     def test_friend_in_january(self):
         friend = self.facebook_users[2]
@@ -37,3 +39,4 @@ class TestTransformer(unittest.TestCase):
         self.assertEqual(friend.profile_picture_uri, 'https://scontent-syd2-1.xx.fbcdn.net/v/t1.0-1/cp0/p60x60/34f34864_10161077510019848_299841799681806933_o.jpg?_nc_cat=107&ccb=2&_nc_sid=7406a8&_nc_ohc=yzAYhtdvoMYAX9Zxo1e&_nc_ht=scontent-syd2-1.xx&tp=27&oh=dc48247e31223151bc5d55781a572e2f&oe=5FD254D0')
         self.assertEqual(friend.birthday_day, 17)
         self.assertEqual(friend.birthday_month, 1)
+        self.assertEqual(friend.birthday_year, 1881)


### PR DESCRIPTION
Changes:
- Use new `BirthdayCometMonthlyBirthdaysRefetchQuery` GraphQL endpoint which seems identical to old `BirthdayCometRootQuery` endpoint but contains birthday year
- Update ICS writer to include Birthday year in description of event
- Handle case when birth year is hidden due to privacy (showing `????` instead)
- Remove special case for overlap logic from #97 as it is no longer needed with the new GraphQL endpoint
- Update tests to support birth year