### PR TITLE
Fixes: #111: Fix token RegExp expression

### DIFF
--- a/fb2cal/utils.py
+++ b/fb2cal/utils.py
@@ -4,3 +4,14 @@ from .facebook_user import FacebookUser
 # This is needed in many cases as the vanity url may change over time
 def generate_facebook_profile_url_permalink(facebook_user: FacebookUser):
     return f'https://www.facebook.com/{facebook_user.id}'
+
+# Facebook prepends an infinite while loop to their API responses as anti hijacking protection
+# It must be stripped away before parsing a response as JSON
+def remove_anti_hijacking_protection(text: str):
+    return remove_prefix(text, "for (;;);")
+
+# Replace with str.removeprefix in Python 3.9+
+def remove_prefix(text, prefix):
+    if text.startswith(prefix):
+        return text[len(prefix):]
+    return text


### PR DESCRIPTION
## Context
- Script has started to fail on JSON decoding of `BirthdayCometMonthlyBirthdaysRefetchQuery` response
- This is because there are additional tokens on the page matching the existing simple regexp `{\"token\":\"(.*?)\"'`

## Changes
- Improve regexp to be more precise (to match desired token to use for `fb_dtsg` parameter)
- Add improved error logging around JSON decoding issues (to allow us to fail early)