### PR TITLE
Python 3.13 support + fix bot detection

### DIFF
--- a/.github/workflows/test-fb2cal.yml
+++ b/.github/workflows/test-fb2cal.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.9', '3.12']
+        python-version: ['3.9', '3.13']
 
     steps:
     - uses: actions/checkout@v3

--- a/fb2cal/__main__.py
+++ b/fb2cal/__main__.py
@@ -19,13 +19,13 @@
 import os
 import sys
 import logging
-from distutils import util
 
 from .ics_writer import ICSWriter
 from .logger import Logger
 from .config import Config
 from .facebook_browser import FacebookBrowser
 from .transformer import Transformer
+from .utils import strtobool
 
 from .__init__ import __version__, __status__, __github_short_url__, __license__
 
@@ -85,7 +85,7 @@ try:
     logger.info('ICS file created successfully.')
 
     # Save to file system
-    if util.strtobool(config['FILESYSTEM']['SAVE_TO_FILE']):
+    if strtobool(config['FILESYSTEM']['SAVE_TO_FILE']):
         ics_writer.write(config['FILESYSTEM']['ICS_FILE_PATH'])
 
     logger.info('Done! Terminating gracefully.')

--- a/fb2cal/facebook_browser.py
+++ b/fb2cal/facebook_browser.py
@@ -4,6 +4,7 @@ import requests
 import json
 from bs4 import Tag
 
+from .__init__ import __version__
 from .logger import Logger
 from .utils import remove_anti_hijacking_protection, facebook_web_encrypt_password
 
@@ -12,7 +13,7 @@ class FacebookBrowser:
         """ Initialize browser as needed """
         self.logger = Logger('fb2cal').getLogger()
         self.browser = mechanicalsoup.StatefulBrowser()
-        self.browser.set_user_agent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36')
+        self.browser.set_user_agent('FB2CAL/{__version__}') # Custom user agent to bypass bot detection / 2FA trigger
         self.__cached_token = None
 
     def _get_datr_token_from_html(self, html):
@@ -67,6 +68,10 @@ class FacebookBrowser:
 
         # Prepare to send form
         login_form = self.browser.select_form("form#login_form")
+        if login_form is None:
+            self.logger.error("Could not find login form.")
+            raise SystemError
+        
         login_form.set("email", email)
 
         # Encrypt password into enc_pass

--- a/fb2cal/facebook_browser.py
+++ b/fb2cal/facebook_browser.py
@@ -4,7 +4,7 @@ import requests
 import json
 from bs4 import Tag
 
-from .__init__ import __version__
+from .__init__ import __title__, __version__
 from .logger import Logger
 from .utils import remove_anti_hijacking_protection, facebook_web_encrypt_password
 
@@ -13,7 +13,7 @@ class FacebookBrowser:
         """ Initialize browser as needed """
         self.logger = Logger('fb2cal').getLogger()
         self.browser = mechanicalsoup.StatefulBrowser()
-        self.browser.set_user_agent('FB2CAL/{__version__}') # Custom user agent to bypass bot detection / 2FA trigger
+        self.browser.set_user_agent('{__title__}/{__version__}') # Custom user agent to bypass bot detection / 2FA trigger
         self.__cached_token = None
 
     def _get_datr_token_from_html(self, html):

--- a/fb2cal/utils.py
+++ b/fb2cal/utils.py
@@ -48,3 +48,13 @@ def facebook_web_encrypt_password(key_id, pub_key, password, version=5):
     encrypted = base64.b64encode(encrypted).decode('utf-8')
 
     return f'#PWD_BROWSER:{version}:{time}:{encrypted}'
+
+# Convert string to boolean based on if its truthy or falsy
+def strtobool(val):
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return True
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return False
+    else:
+        raise ValueError(f"invalid truth value {val!r}")

--- a/setup.py
+++ b/setup.py
@@ -51,5 +51,6 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )


### PR DESCRIPTION
Changes:

- Support Python 3.12
- Avoid Facebook's bot detection that resulted in (#126) by simply changing the user-agent. This avoids the redirect to the additional 2FA flow. This works for now as quick win but in the future we may have to mimic client side login flow more precisely to bypass the 2FA flow.

Fixes #126